### PR TITLE
fix: 2020/11/26 not change contributions color bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+### v1.7.3 / 2020-11-26
+
+ - Fix not apply Contribution colors bug.
+
 ### v1.7.2 / 2020-10-30
 
   - Fix contribution graph and progress bar colors (new GitHub CSS variables)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# How to use personaly
+
+## 1. Download this project
+## 2. Open your browser(chrome, chromiun, new edge) and go 'chrome://extensions'
+## 3. And Click '압축해제된 확장 프로그램을 로드합니다를' text, first button.
+## 4. upload your src folder from 1. step
+## 5. Just finish. Go github profile! You can see changed contributions color. 🥰
+
 <p align="center">
   <img alt="GitHub Contribution Color Graph" src="https://raw.githubusercontent.com/williambelle/github-contribution-color-graph/master/assets/readme-logo.png">
 </p>

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # How to use personaly
 
-## 1. Download this project
-## 2. Open your browser(chrome, chromiun, new edge) and go 'chrome://extensions'
-## 3. And Click '압축해제된 확장 프로그램을 로드합니다를' text, first button.
-## 4. upload your src folder from 1. step
-## 5. Just finish. Go github profile! You can see changed contributions color. 🥰
+- ## 1. Download this project
+- ## 2. Open your browser(chrome, chromiun, new edge) and go 'chrome://extensions'
+- ## 3. And Click '압축해제된 확장 프로그램을 로드합니다' text, first button.
+- ## 4. upload your src folder from 1. step
+- ## 5. Just finish. Go github profile! You can see changed contributions color. 🥰
 
 <p align="center">
   <img alt="GitHub Contribution Color Graph" src="https://raw.githubusercontent.com/williambelle/github-contribution-color-graph/master/assets/readme-logo.png">

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 - ## 1. Download this project
 - ## 2. Open your browser(chrome, chromiun, new edge) and go 'chrome://extensions'
-- ## 3. And Click '압축해제된 확장 프로그램을 로드합니다' text, first button.
-- ## 4. upload your 'src' folder in (1. step)
+- ## 3. And click '압축해제된 확장 프로그램을 로드합니다' text, first button.
+- ## 4. Upload your 'src' folder in (1. step)
 - ## 5. Just finish. Go github profile! You can see changed contributions color. 🥰
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 - ## 1. Download this project
 - ## 2. Open your browser(chrome, chromiun, new edge) and go 'chrome://extensions'
-- ## 3. And click '압축해제된 확장 프로그램을 로드합니다' text, first button.
+- ## 3. And click '압축해제된 확장 프로그램을 로드합니다' or 'Load Unpacked' text, first button.
 - ## 4. Upload your 'src' folder in (1. step)
 - ## 5. Just finish. Go github profile! You can see changed contributions color. 🥰
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 - ## 1. Download this project
 - ## 2. Open your browser(chrome, chromiun, new edge) and go 'chrome://extensions'
 - ## 3. And Click '압축해제된 확장 프로그램을 로드합니다' text, first button.
-- ## 4. upload your src folder from 1. step
+- ## 4. upload your 'src' folder in (1. step)
 - ## 5. Just finish. Go github profile! You can see changed contributions color. 🥰
 
 <p align="center">

--- a/src/js/contentscript.js
+++ b/src/js/contentscript.js
@@ -128,6 +128,17 @@ function applyColorToActivity (color) {
   }
 }
 
+function changeContributionsColor(color) {
+  document.querySelectorAll("rect").forEach((element) => {
+    const colorIndex = github.findIndex(
+      (githubColor) => githubColor === element.getAttribute("fill")
+    );
+    if (colorIndex !== -1) {
+      element.setAttribute("fill", color[colorIndex]);
+    }
+  });
+}
+
 function applyOptions () {
   chrome.storage.local.get('favoriteColor', function (color) {
     if (!color.favoriteColor) {
@@ -135,9 +146,10 @@ function applyOptions () {
     } else if (color.favoriteColor === 'random') {
       color.favoriteColor = randomColor;
     }
-    applyColorToCssGitHubVars(colors[color.favoriteColor]);
+    // applyColorToCssGitHubVars(colors[color.favoriteColor]);
     applyColorToLegend(colors[color.favoriteColor]);
     applyColorToActivity(colors[color.favoriteColor]);
+    changeContributionsColor(colors[color.favoriteColor]);
   });
 }
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "name": "GitHub Contribution Color Graph",
   "description": "Change colors of contribution graph in GitHub",
   "manifest_version": 2,
-  "version": "1.7.2",
+  "version": "1.7.3",
 
   "content_scripts": [{
     "js": [ "js/contentscript.js" ],


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/48552260/100364032-e56b8080-3040-11eb-880a-912aceba9245.png)
2020/11/26 Now, GitHub still doesn't use `--color-calendar-graph-day-...` this pattern. As you can see using fill property in rect element. So, I fix this error! 😊