### PR TITLE
use browser built-in options_ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+### unreleased
+  - use browser built-in `options_ui`
+
 ### v1.7.2 / 2020-10-30
 
   - Fix contribution graph and progress bar colors (new GitHub CSS variables)

--- a/src/css/options.css
+++ b/src/css/options.css
@@ -14,30 +14,6 @@ body {
   box-shadow: 0px 0px 10px #DDD;
 }
 
-#logo {
-  margin: -5px 10px -5px 0;
-  width: 32px;
-  float: left;
-}
-
-h1 {
-  color: #333;
-  font-size: 1.5em;
-  margin: 0.7em 0 0;
-}
-
-#header {
-  background: linear-gradient(white, #EEE);
-  padding: 15px 0px 10px 10px;
-  height: 30px;
-  border-bottom: 1px solid #DDD;
-  margin: -12px -12px 20px -12px;
-  border-top-left-radius: 10px;
-  border-top-right-radius: 10px;
-  text-shadow: 1px 1px 1px white;
-  color: #666;
-}
-
 p {
   font-size: 12px;
 }

--- a/src/css/options.css
+++ b/src/css/options.css
@@ -1,43 +1,28 @@
-body {
-  background-color: #EEE;
-  font-family: arial, sans-serif;
-  font-size: 13px
 }
 
 #content {
-  background-color: white;
-  border: 1px solid #DDD;
-  margin: 40px auto 20px;
-  padding: 12px;
-  width: 500px;
-  -webkit-border-radius: 12px;
-  box-shadow: 0px 0px 10px #DDD;
+  margin: 1em auto;
+  text-align: center;
 }
 
-p {
-  font-size: 12px;
+#content span {
+  margin-right: 1em;
 }
 
 hr {
   border: 1px solid #EEE;
-  border-bottom: none;
-  margin: 10px 0px;
 }
 
 #status {
   color: green;
+  text-align: center;
+  margin: auto;
 }
 
 button {
   cursor: pointer;
-  background-image: linear-gradient(white, #EEE);
   color: #333;
-  border: 1px solid #CCC;
-  border-radius: 2px;
-  margin: 0px 1px 0px 0px;
-  outline: none;
   min-height: 2em;
-  text-align: center;
 }
 
 button:hover {

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -18,8 +18,7 @@
   }],
 
   "options_ui": {
-    "page": "options.html",
-    "open_in_tab": true
+    "page": "options.html"
   },
 
   "permissions": [

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -11,8 +11,7 @@
   }],
 
   "options_ui": {
-    "page": "options.html",
-    "open_in_tab": true
+    "page": "options.html"
   },
 
   "permissions": [

--- a/src/options.html
+++ b/src/options.html
@@ -8,8 +8,7 @@
 
 <body>
   <div id="content">
-    <p>Choose graph color</p>
-    <p>
+      <span>Graph Color</span>
       <select id="color">
         <option value="github">GitHub Default</option>
         <option value="halloween">Halloween</option>
@@ -44,7 +43,6 @@
         <option disabled>──────────</option>
         <option value="random">Random</option>
       </select>
-    </p>
 
     <hr />
 

--- a/src/options.html
+++ b/src/options.html
@@ -9,7 +9,7 @@
 <body>
   <div id="content">
       <span>Graph Color</span>
-      <select id="color">
+      <select class="browser-style" id="color">
         <option value="github">GitHub Default</option>
         <option value="halloween">Halloween</option>
         <option disabled>──────────</option>
@@ -46,7 +46,7 @@
 
     <hr />
 
-    <button id="save">Save my preference</button>
+    <button class="browser-style" id="save">Save preference</button>
     <span id="status"></span>
   </div>
 

--- a/src/options.html
+++ b/src/options.html
@@ -8,9 +8,6 @@
 
 <body>
   <div id="content">
-    <img id="logo" src="images/icon-48.png" alt="logo" />
-    <h1 id="header">GitHub Contribution Color Graph Options</h1>
-
     <p>Choose graph color</p>
     <p>
       <select id="color">


### PR DESCRIPTION
Opening the extension's `options_ui` in a separate tab is an old
method. Browsers now provide a built-in `options_ui` within the
Extension's listing page itself.

This changeset changes the `options_ui` behaviour to open within the
extension's listing context itself.

This can also avoid confusions like issue #35. I myself had the same
confusion on Firefox. On Chrom{e,ium}, at least, there is a default
button on the toolbar which the user can click and find the 'Options'
page. On Firefox, there is none. Finding the 'Preferences' option
within the overflow menu of the extension is too far-fetched to find.
I got to #35 searching for how to change the theme on Firefox.

Resolves https://github.com/williambelle/github-contribution-color-graph/issues/35
